### PR TITLE
A few enhancements for urxvt-tabbedex

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -74,6 +74,9 @@
 ##     tabbedex:move_tab_(left|right).
 ##     e.g. (see 9.) URxvt.keysym.C-S-Left: perl:tabbex:move_tab_left
 ##
+## 12. Ability to disable the default keybindings using the
+##     no-tabbedex-keys resource.
+##
 
 
 sub update_autohide {
@@ -368,6 +371,8 @@ sub on_init {
       ($self->x_resource ('title') or 'true') !~ /^(?:false|0|no)/i;
    $self->{autohide} =
       ($self->x_resource ('autohide') or 'false') !~ /^(?:false|0|no)/i;
+   $self->{no_default_keys} =
+      ($self->x_resource ('no-tabbedex-keys') or 'false') !~ /^(?:false|0|no)/i;
 
    ();
 }
@@ -491,6 +496,8 @@ sub tab_key_press {
       $self->refresh;
       return 1;
    }
+
+   return () if ($self->{no_default_keys});
 
    if ($event->{state} & urxvt::ShiftMask) {
       if ($keysym == 0xff51 || $keysym == 0xff53) {

--- a/tabbedex
+++ b/tabbedex
@@ -68,6 +68,12 @@
 ##     to other extension packages if the mouse was not over the urxvt
 ##     window.
 ##
+## Added by Thomas Jost:
+##
+## 11. Add several user commands: tabbedex:rename_tab,
+##     tabbedex:move_tab_(left|right).
+##     e.g. (see 9.) URxvt.keysym.C-S-Left: perl:tabbex:move_tab_left
+##
 
 
 sub update_autohide {
@@ -498,25 +504,12 @@ sub tab_key_press {
          return 1;
 
       } elsif ($keysym == 0xff52) {
-         $tab->{is_inputting_name} = 1;
-         $tab->{old_name} = $tab->{name} ? $tab->{name} : "";
-         $tab->{new_name} = "";
-         $tab->{name} = "█";
-         $self->update_autohide (1);
-         $self->refresh;
+         $self->rename_tab($tab);
          return 1;
       }
    } elsif ($event->{state} & urxvt::ControlMask) {
       if ($keysym == 0xff51 || $keysym == 0xff53) {
-         if (@{ $self->{tabs} } > 1) {
-            my $idx1 = 0;
-            ++$idx1 while $self->{tabs}[$idx1] != $tab;
-            my $idx2 = ($idx1 + $keysym - 0xff52) % @{ $self->{tabs} };
-
-            ($self->{tabs}[$idx1], $self->{tabs}[$idx2]) =
-                ($self->{tabs}[$idx2], $self->{tabs}[$idx1]);
-            $self->make_current ($self->{tabs}[$idx2]);
-         }
+         $self->move_tab($tab, $keysym - 0xff52);
          return 1;
       }
    }
@@ -556,6 +549,15 @@ sub tab_user_command {
   elsif ($cmd eq 'tabbedex:prev_tab') {
     $self->change_tab($tab, -1);
   }
+  elsif ($cmd eq 'tabbedex:move_tab_left') {
+    $self->move_tab($tab, -1);
+  }
+  elsif ($cmd eq 'tabbedex:move_tab_right') {
+    $self->move_tab($tab, 1);
+  }
+  elsif ($cmd eq 'tabbedex:rename_tab') {
+    $self->rename_tab($tab);
+  }
   else {
     # Proxy the user command through to the tab's term, while taking care not
     # to get caught in an infinite loop.
@@ -576,6 +578,35 @@ sub change_tab {
   ++$idx while $self->{tabs}[$idx] != $tab;
   $idx += $direction;
   $self->make_current ($self->{tabs}[$idx % @{ $self->{tabs}}]);
+
+  ();
+}
+
+sub move_tab {
+  my ($self, $tab, $direction) = @_;
+
+  if (@{ $self->{tabs} } > 1) {
+    my $idx1 = 0;
+    ++$idx1 while $self->{tabs}[$idx1] != $tab;
+    my $idx2 = ($idx1 + $direction) % @{ $self->{tabs} };
+
+    ($self->{tabs}[$idx1], $self->{tabs}[$idx2]) =
+      ($self->{tabs}[$idx2], $self->{tabs}[$idx1]);
+    $self->make_current ($self->{tabs}[$idx2]);
+  }
+
+  ();
+}
+
+sub rename_tab {
+  my ($self, $tab) = @_;
+
+  $tab->{is_inputting_name} = 1;
+  $tab->{old_name} = $tab->{name} ? $tab->{name} : "";
+  $tab->{new_name} = "";
+  $tab->{name} = "█";
+  $self->update_autohide (1);
+  $self->refresh;
 
   ();
 }


### PR DESCRIPTION
Hi,

First of all, thanks for maintaining tabbedex, it's really useful :-)

As the default Shift+arrows and Ctrl+arrows sometimes cause conflicts in a few applications I use, I wrote 2 patches that:
1. make it possible to rename a tab and move tabs using user commands
2. make it possible to simply _disable_ the default keybindings

This allows me to use all the tabbedex features with [custom keybindings](https://github.com/Schnouki/dotfiles/blob/6b08d4abce7c22f993b885b43744daba06fb2066/Xdefaults#L55).

Please consider merging this. If you think there is a better way to do it, please tell me and I will try to improve what I did.

Thanks,
Thomas
