### PR TITLE
Fix displaying non-latin characters in tab title

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -68,7 +68,7 @@
 ##     to other extension packages if the mouse was not over the urxvt
 ##     window.
 ##
-
+use Encode qw(decode);
 
 sub update_autohide {
    my ($self, $reconfigure) = @_;
@@ -141,7 +141,7 @@ sub refresh {
       my $term = $self->{term};
       my @str = $term->XGetWindowProperty($term->parent, $self->{tab_title});
       if (@str && $str[2]) {
-         my $str = '| ' . $str[2];
+         my $str = '| ' . decode("utf8", $str[2]);
          my $len = length $str;
          $len = $ncol - $ofs if $ofs + $len > $ncol;
          substr $text, $ofs, $len, substr $str, 0, $len;
@@ -384,7 +384,7 @@ sub on_start {
    } while @argv && $argv[0] ne "-e";
 
    if ($self->{tab_title}) {
-      $self->{tab_title} = $self->{term}->XInternAtom("WM_NAME", 1);
+      $self->{tab_title} = $self->{term}->XInternAtom("_NET_WM_NAME", 1);
    }
 
    $self->new_tab (@argv);


### PR DESCRIPTION
Right now tabbedex is unable to display non-latin characters in tab title, since it is accessing WM_NAME property, which contains invalid representation of non-latin characters.

According to http://standards.freedesktop.org/wm-spec/1.3/ar01s05.html :

> _NET_WM_NAME, UTF8_STRING
> 
> The Client SHOULD set this to the title of the window in UTF-8 encoding. If set, the Window Manager should use this in preference to WM_NAME. 

I'm not sure if there are still any app, which do not set _NET_WM_NAME (I can't find it).

If required we could provide a fallback to WM_NAME but right now this fixes behaviour for non-latin characters for all of my system
