### PR TITLE
apply command line options to tabbed terminals

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -187,6 +187,11 @@ sub new_tab {
             if defined $value;
       }
 
+      foreach my $opt (keys %urxvt::OPTION) {
+          my $value = $self->{option}{$opt};
+          $term->option($urxvt::OPTION{$opt}, $value);
+      }
+
       $term->resource (perl_ext_2 => $term->resource ("perl_ext_2") . ",-tabbedex");
    };
 
@@ -326,11 +331,17 @@ sub on_init {
    my ($self) = @_;
 
    $self->{resource} = [map $self->resource ("+$_"), 0 .. urxvt::NUM_RESOURCES - 1];
-
+   
    $self->resource (int_bwidth => 0);
    $self->resource (name => "URxvt.tabbed");
    $self->resource (pty_fd => -1);
 
+   $self->{option} = {};
+   for my $key (keys %urxvt::OPTION) {
+       $self->{option}{$key} = $self->option($urxvt::OPTION{$key});
+   }
+
+   # this is for the tabs terminal; order is important
    $self->option ($urxvt::OPTION{scrollBar}, 0);
 
    my $fg    = $self->x_resource ("tabbar-fg");


### PR DESCRIPTION
Specifically, the scrollbar (+sb, -sb) options were not being honored by the subterminals, but probably others as well.  This is an issue in the official tabbed extension for rxvt-unicode as well.  
