### PR TITLE
Fix qw syntax error

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -564,7 +564,6 @@ sub tab_key_press {
          return 1;
       }
       elsif ($keysym == 0xff54) {
-         print "destroy\n";
          $tab->destroy;
          return 1;
       }

--- a/tabbedex
+++ b/tabbedex
@@ -94,6 +94,9 @@
 ##     Use the following in your ~/.Xdefaults to enable:
 ##     URXvt.tabbed.reopen-on-close: yes
 ##
+## 17. Destroy a tab with C-Down
+##
+## Keysym reference http://www.tcl.tk/man/tcl8.4/TkCmd/keysyms.htm
 
 use Encode qw(decode);
 
@@ -558,6 +561,11 @@ sub tab_key_press {
    } elsif ($event->{state} & urxvt::ControlMask) {
       if ($keysym == 0xff51 || $keysym == 0xff53) {
          $self->move_tab($tab, $keysym - 0xff52);
+         return 1;
+      }
+      elsif ($keysym == 0xff54) {
+         print "destroy\n";
+         $tab->destroy;
          return 1;
       }
    }

--- a/tabbedex
+++ b/tabbedex
@@ -665,7 +665,7 @@ package urxvt::ext::tabbedex::tab;
 # simply proxies all interesting calls back to the tabbedex class.
 
 {
-   for my $hook qw(start destroy user_command key_press property_notify add_lines) {
+   for my $hook ( qw(start destroy user_command key_press property_notify add_lines) ) {
       eval qq{
          sub on_$hook {
             my \$parent = \$_[0]{term}{parent}


### PR DESCRIPTION
Fixes syntax error:

```
urxvt: perl hook 0 evaluation error: /usr/lib/urxvt/perl/tabbedex: syntax error at /usr/lib/urxvt/perl/tabbedex line 669, near "$hook qw(start destroy user_command key_press property_notify add_lines)"
syntax error at /usr/lib/urxvt/perl/tabbedex line 681, near "}

}"
```
