### PR TITLE
Allow UTF8 special characters as timeout markers.

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -388,6 +388,7 @@ sub on_init {
 
    my $timeouts = $self->my_resource ("tabbar-timeouts");
    $timeouts = '16:.:8:::4:+' unless defined $timeouts;
+   $timeouts = decode("utf8", $timeouts);
    if ($timeouts ne '') {
       my @timeouts;
       while ($timeouts =~ /^(\d+):(.)(?::(.*))?$/) {


### PR DESCRIPTION
Normally something like
    URxvt*tabbar-timeouts:240:_:120:▁:60:▂:30:▃:15:▄:10:▅:5:▆:2:▇:1:█
wouldn't work. With this it does.
