### PR TITLE
Fix use of qw as parentheses in loop

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -665,7 +665,7 @@ package urxvt::ext::tabbedex::tab;
 # simply proxies all interesting calls back to the tabbedex class.
 
 {
-   for my $hook qw(start destroy user_command key_press property_notify add_lines) {
+   for my $hook (qw(start destroy user_command key_press property_notify add_lines)) {
       eval qq{
          sub on_$hook {
             my \$parent = \$_[0]{term}{parent}


### PR DESCRIPTION
This is no longer valid in perl 5.18, should have warned terribly in 5.16. 

https://metacpan.org/pod/release/RJBS/perl-5.18.0/pod/perldelta.pod#qw-...-can-no-longer-be-used-as-parentheses
