### PR TITLE
Fix for "perl hook 0 evaluation error" with perl v5.18.2

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -665,7 +665,7 @@ package urxvt::ext::tabbedex::tab;
 # simply proxies all interesting calls back to the tabbedex class.
 
 {
-   for my $hook qw(start destroy user_command key_press property_notify add_lines) {
+   for my $hook (qw(start destroy user_command key_press property_notify add_lines)) {
       eval qq{
          sub on_$hook {
             my \$parent = \$_[0]{term}{parent}


### PR DESCRIPTION
Fix for the perl hook 0 evaluation error with perl v5.18.2 initially provided by lomov_vl:
https://bbs.archlinux.org/viewtopic.php?pid=1277245#p1277245

urxvt: perl hook 0 evaluation error: tabbedex
syntax error at tabbedex line 6
syntax error at tabbedex line 681, near "}
