### PR TITLE
simplify redrawing the tabbar and trunc the title

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -135,51 +135,88 @@ sub refresh {
 
    my $ncol = $self->ncol;
 
-   my $text = " " x $ncol;
-   my $rend = [($self->{rs_tabbar}) x $ncol];
-
-   my ($ofs, $idx, @ofs) = (0, 0);
+   # $text holds the actual text that will be rendered to the screen
+   my $text = "";
+   # $rend holds the colors that will be rendered to the screen
+   my @rend;
+   # index of the current tab
+   my $tab_index = 0;
+   # offsets for the clickable areas [start, end, type]
+   my @ofs;
 
    if ($self->{new_button}) {
-      substr $text, 0, 7, "[NEW] |";
-      @$rend[0 .. 5] = ($self->{rs_tab}) x 6;
-      push @ofs, [0, 6, -1 ];
-      $ofs = 7;
+      $text .= "[NEW] |";
+      push @rend, ($self->{rs_tab}) x 6;
+      push @ofs, [0, 6, -1]; # make the first six characters the new tab button
    }
 
+   my $ofs = length $text;
    for my $tab (@{ $self->{tabs} }) {
-      my $name = $tab->{name} ? $tab->{name} : $idx;
-      my $act = $self->tab_activity_mark($tab);
-      my $txt = sprintf "%s%s%s", $act, $name, $act;
-      my $len = length $txt;
+      my $name    = $tab->{name} ? $tab->{name} : $tab_index;
+      my $act     = $self->tab_activity_mark($tab);
+      $text      .= "$act$name$act|";
+      my $tab_len = 2 + length $name;
 
-      substr $text, $ofs, $len + 1, "$txt|";
-      @$rend[$ofs .. $ofs + $len - 1] = ($self->{rs_tab}) x $len
-         if $tab == $self->{cur};
+      if ($tab == $self->{cur}) {
+         push @rend, ($self->{rs_tab}) x $tab_len, $self->{rs_tabbar};
+      } else {
+         push @rend, ($self->{rs_tabbar}) x (1 + $tab_len);
+      }
 
-      push @ofs, [ $ofs, $ofs + $len, $idx ];
-      ++$idx;
-      $ofs += $len + 1;
+      # make the title and the activity marks clickable
+      push @ofs, [ $ofs, $ofs + $tab_len, $tab_index ];
+      $ofs += $tab_len + 1; # the +1 takes into account the |
+
+      # no point in continuing to write tabs if they are off screen
+      # FIXME: make tab double height when this happens (or triple, etc.)
+      # probably need to make $text an array, @rend a multidimensional array
+      # make multiple calls to ROW_[t|r], and do something interesting to
+      # $self->{tabofs}
+      last if $ncol <= length $text;
+
+      ++$tab_index;
    }
 
-   substr $text, --$ofs, 1, ' '; # remove last '|'
+   # remove last |
+   $text =~ s/\|$//;
+   pop @rend;
 
-   if ($self->{tab_title} && $ofs + 3 < $ncol) {
+   if ($self->{tab_title}) {
       my $term = $self->{term};
-      my @str = $term->XGetWindowProperty($term->parent, $self->{tab_title});
+      my @str  = $term->XGetWindowProperty($term->parent, $self->{tab_title});
       if (@str && $str[2]) {
-         my $str = '| ' . decode("utf8", $str[2]);
-         my $len = length $str;
-         $len = $ncol - $ofs if $ofs + $len > $ncol;
-         substr $text, $ofs, $len, substr $str, 0, $len;
-         @$rend[$ofs + 2 .. $ofs + $len - 1] = ($self->{rs_title}) x ($len - 2);
+         my $title      = decode("utf8", $str[2]);
+         my $title_len  = length $title;
+         my $tabbar_len = 2 + length $text; # the 2 takes into account the "| "
+
+         #trim title to fit length
+         if ($title_len + $tabbar_len > $ncol) {
+            my $remaining = $ncol - $tabbar_len;
+            if ($remaining > 0) {
+               # if we can't fit the title, truncate it and add an
+               # ellipsis to indicate the truncation
+               $title = substr $title, 0, $remaining - 1;
+               $title .= "\x{2026}";
+            }
+         }
+
+         # FIXME: add option to right justify title
+         $text .= "| " . $title;
+         push @rend,
+            ($self->{rs_tabbar}) x 2,
+            ($self->{rs_title})  x (length $title);
       }
    }
 
+   # pad the text and color out to the end
+   my $left_over = ($ncol - length $text);
+   $text .= " " x $left_over;
+   push @rend, ($self->{rs_tabbar}) x $left_over;
+
    $self->{tabofs} = \@ofs;
 
-   $self->ROW_t (0, $text, 0, 0, $ncol);
-   $self->ROW_r (0, $rend, 0, 0, $ncol);
+   $self->ROW_t (0, $text,  0, 0, $ncol);
+   $self->ROW_r (0, \@rend, 0, 0, $ncol);
 
    $self->want_refresh;
 }


### PR DESCRIPTION
Simplified the redrawing of the tab bar to make life easier for my next
change: optionally right justifying the title.  I also made it
stop trying to draw tabs after the end of the screen and added
a truncation indication (ellipsis) when the title gets truncated
