### PR TITLE
Fix a syntax error with recent Perl versions

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -665,7 +665,7 @@ package urxvt::ext::tabbedex::tab;
 # simply proxies all interesting calls back to the tabbedex class.
 
 {
-   for my $hook qw(start destroy user_command key_press property_notify add_lines) {
+   for my $hook (qw(start destroy user_command key_press property_notify add_lines)) {
       eval qq{
          sub on_$hook {
             my \$parent = \$_[0]{term}{parent}


### PR DESCRIPTION
I'm do not know Perl very much, but I guess this is a problem with more current Perl versions.